### PR TITLE
Missing ;, bug for platform type is user error

### DIFF
--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -56,7 +56,7 @@ const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = 
 };
 const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
   A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13,A14,A15
-}
+};
 #else
 #define CPU_TYPE_ERROR
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,3 +34,10 @@ board = uno
 framework = arduino
 monitor_speed = 115200
 monitor_echo = yes
+
+[env:mega2560]
+platform = atmelavr
+board = megaatmega2560
+framework = arduino
+monitor_speed = 115200
+monitor_echo = yes


### PR DESCRIPTION
; missing from SupportedDevices.h which causes Mega compile error, and Mega missing from platformio.ini

The bug detecting Uno was a user error on my part, have tested Uno is detected correctly in both PlatformIO and Arduino IDE