### PR TITLE
6-feature-request-add-support-for-interactive-configuration-of-i2c-address

### DIFF
--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -442,7 +442,7 @@ uint8_t getI2CAddress() {
     }
   }
   if (addressSet) {
-    eepromAddress = EEPROM.read(6);
+    eepromAddress = EEPROM.read(5);
 #ifdef DIAG
       Serial.print(F("I2C address defined in EEPROM: 0x"));
       Serial.println(eepromAddress, HEX);
@@ -464,14 +464,14 @@ void writeI2CAddress(int16_t eepromAddress) {
   for (uint8_t i = 0; i < 5; i++) {
     EEPROM.write(i, eepromData[i]);
   }
-  EEPROM.write(6, eepromAddress);
+  EEPROM.write(5, eepromAddress);
 }
 
 /*
 * Function to erase EEPROM contents
 */
 void eraseEEPROM() {
-  for (uint8_t i = 0; i < 7; i++) {
+  for (uint8_t i = 0; i < 6; i++) {
     EEPROM.write(i, 0);
   }
 }

--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -27,6 +27,9 @@
 
 #include <Arduino.h>
 #include "SupportedDevices.h"
+#ifdef HAS_EEPROM
+#include <EEPROM.h>
+#endif
 
 #ifdef CPU_TYPE_ERROR
 #error Unsupported microcontroller architecture detected, you need to use a type listed in defines.h
@@ -89,6 +92,9 @@ bool setupComplete = false;   // Flag when initial configuration/setup has been 
 uint8_t outboundFlag;   // Used to determine what data to send back to the CommandStation
 byte analogueOutBuffer[2];  // Array to send requested LSB/MSB of the analogue value to the CommandStation
 byte digitalOutBuffer[1];   // Array to send digital value to CommandStation
+bool newSerialData = false;   // Flag for new serial data being received
+const byte numSerialChars = 10;   // Max number of chars for serial input
+char serialInputChars[numSerialChars];  // Char array for serial input
 #ifdef DIAG
 unsigned long lastPinDisplay = 0;   // Last time in millis we displayed DIAG input states
 #endif
@@ -108,6 +114,11 @@ void setup() {
   Serial.println(VERSION);
   Serial.print(F("Detected device: "));
   Serial.println(BOARD_TYPE);
+#ifdef HAS_EEPROM
+  if (getI2CAddress() != 0) {
+    i2cAddress = getI2CAddress();
+  }
+#endif
   if (i2cAddress < 0x08 || i2cAddress > 0x77) {
     Serial.print(F("ERROR: Invalid I2C address configured: 0x"));
     Serial.println(i2cAddress, HEX);
@@ -152,9 +163,10 @@ void loop() {
       }
     }
   }
-  #ifdef DIAG
+#ifdef DIAG
   displayPins();
 #endif
+  processSerialInput();
 }
 
 /*
@@ -287,7 +299,7 @@ void requestEvent() {
 }
 
 /*
-* Function to display pin configuratin and states when DIAG enabled
+* Function to display pin configuration and states when DIAG enabled
 */
 #ifdef DIAG
 void displayPins() {
@@ -325,6 +337,134 @@ void displayPins() {
         Serial.print(F(","));
       }
     }
+  }
+}
+#endif
+
+/*
+* Function to read and process serial input for I2C address config
+*/
+void processSerialInput() {
+  static bool serialInProgress = false;
+  static byte serialIndex = 0;
+  char startMarker = '<';
+  char endMarker = '>';
+  char serialChar;
+  while (Serial.available() > 0 && newSerialData == false) {
+    serialChar = Serial.read();
+    if (serialInProgress == true) {
+      if (serialChar != endMarker) {
+        serialInputChars[serialIndex] = serialChar;
+        serialIndex++;
+        if (serialIndex >= numSerialChars) {
+          serialIndex = numSerialChars - 1;
+        }
+      } else {
+        serialInputChars[serialIndex] = '\0';
+        serialInProgress = false;
+        serialIndex = 0;
+        newSerialData = true;
+      }
+    } else if (serialChar == startMarker) {
+      serialInProgress = true;
+    }
+  }
+  if (newSerialData == true) {
+    newSerialData = false;
+    char * strtokIndex;
+    strtokIndex = strtok(serialInputChars," ");
+    char activity = strtokIndex[0];    // activity is our first parameter
+    strtokIndex = strtok(NULL," ");       // space is null, separator
+    unsigned long newAddress = strtol(strtokIndex, NULL, 16); // last parameter is the address in hex
+#ifdef DIAG
+    Serial.print(F("Perform activity "));
+    Serial.print(activity);
+    Serial.print(F(" for I2C address 0x"));
+    Serial.println(newAddress, HEX);
+#endif
+    switch (activity) {
+      case 'W':
+        if (newAddress > 0x07 && newAddress < 0x78) {
+#ifdef HAS_EEPROM
+          Serial.print(F("Saving address 0x"));
+          Serial.print(newAddress, HEX);
+          Serial.println(F(" to EEPROM, reboot to activate"));
+          writeI2CAddress(newAddress);
+#else
+          Serial.println(F("No EEPROM support, ignoring"));
+#endif
+        } else {
+          Serial.println(F("Invalid I2C address, must be between 0x08 and 0x77"));
+        }
+        break;
+      case 'E':
+        eraseEEPROM();
+        Serial.println(F("Erased EEPROM, reboot to revert to default"));
+        break;
+      case 'R':
+        if (getI2CAddress() == 0) {
+          Serial.println(F("I2C address not stored in EEPROM"));
+        } else {
+          Serial.print(F("I2C address stored in EEPROM is 0x"));
+          Serial.println(getI2CAddress(), HEX);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+// EEPROM functions here, only for uCs with EEPROM support
+#ifdef HAS_EEPROM
+/*
+* Function to read I2C address from EEPROM
+* Look for "EXIO" and the version EEPROM_VERSION at 0 to 5, address at 6
+*/
+uint8_t getI2CAddress() {
+  char data[5];
+  char eepromData[5] = {'E', 'X', 'I', 'O', EEPROM_VERSION};
+  uint8_t eepromAddress;
+  bool addressSet = true;
+  for (uint8_t i = 0; i < 5; i ++) {
+    data[i] = EEPROM.read(i);
+    if (data[i] != eepromData[i]) {
+      addressSet = false;
+      break;
+    }
+  }
+  if (addressSet) {
+    eepromAddress = EEPROM.read(6);
+#ifdef DIAG
+      Serial.print(F("I2C address defined in EEPROM: 0x"));
+      Serial.println(eepromAddress, HEX);
+#endif
+    return eepromAddress;
+  } else {
+#ifdef DIAG
+    Serial.println(F("I2C address not defined in EEPROM"));
+#endif
+    return 0;
+  }
+}
+
+/*
+* Function to store I2C address in EEPROM
+*/
+void writeI2CAddress(int16_t eepromAddress) {
+  char eepromData[5] = {'E', 'X', 'I', 'O', EEPROM_VERSION};
+  for (uint8_t i = 0; i < 5; i++) {
+    EEPROM.write(i, eepromData[i]);
+  }
+  EEPROM.write(6, eepromAddress);
+}
+
+/*
+* Function to erase EEPROM contents
+*/
+void eraseEEPROM() {
+  for (uint8_t i = 0; i < 7; i++) {
+    EEPROM.write(i, 0);
   }
 }
 #endif

--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -398,16 +398,24 @@ void processSerialInput() {
         }
         break;
       case 'E':
+#ifdef HAS_EEPROM
         eraseEEPROM();
         Serial.println(F("Erased EEPROM, reboot to revert to default"));
+#else
+          Serial.println(F("No EEPROM support, ignoring"));
+#endif
         break;
       case 'R':
+#ifdef HAS_EEPROM
         if (getI2CAddress() == 0) {
           Serial.println(F("I2C address not stored in EEPROM"));
         } else {
           Serial.print(F("I2C address stored in EEPROM is 0x"));
           Serial.println(getI2CAddress(), HEX);
         }
+#else
+          Serial.println(F("No EEPROM support, ignoring"));
+#endif
         break;
       default:
         break;

--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -74,6 +74,13 @@ analogueConfig analoguePins[NUMBER_OF_ANALOGUE_PINS];
 /*
 * Global variables here
 */
+/*
+* If for some reason the I2C address isn't defined, define our default here.
+*/
+#ifndef I2C_ADDRESS
+#define I2C_ADDRESS 0x65
+#endif
+uint8_t i2cAddress = I2C_ADDRESS;   // Assign address to a variable for validation and serial input
 uint8_t numDigitalPins = NUMBER_OF_DIGITAL_PINS;    // Init with default, will be overridden by config
 uint8_t numAnaloguePins = NUMBER_OF_ANALOGUE_PINS;  // Init with default, will be overridden by config
 int digitalPinBytes;  // Used for configuring and sending/receiving digital pins
@@ -84,13 +91,6 @@ byte analogueOutBuffer[2];  // Array to send requested LSB/MSB of the analogue v
 byte digitalOutBuffer[1];   // Array to send digital value to CommandStation
 #ifdef DIAG
 unsigned long lastPinDisplay = 0;   // Last time in millis we displayed DIAG input states
-#endif
-
-/*
-* If for some reason the I2C address isn't defined, define our default here.
-*/
-#ifndef I2C_ADDRESS
-#define I2C_ADDRESS 0x65
 #endif
 
 /*
@@ -108,9 +108,14 @@ void setup() {
   Serial.println(VERSION);
   Serial.print(F("Detected device: "));
   Serial.println(BOARD_TYPE);
+  if (i2cAddress < 0x08 || i2cAddress > 0x77) {
+    Serial.print(F("ERROR: Invalid I2C address configured: 0x"));
+    Serial.println(i2cAddress, HEX);
+    i2cAddress = 0x65;
+  }
   Serial.print(F("Available at I2C address 0x"));
-  Serial.println(I2C_ADDRESS, HEX);
-  Wire.begin(I2C_ADDRESS);
+  Serial.println(i2cAddress, HEX);
+  Wire.begin(i2cAddress);
   // Need to intialise every pin in INPUT mode (no pull ups) for safe start
   for (uint8_t pin = 0; pin < NUMBER_OF_DIGITAL_PINS; pin++) {
     pinMode(digitalPinMap[pin], INPUT);

--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -34,6 +34,7 @@ static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_P
 static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
   A0,A1,A2,A3
 };
+
 // Arduino Nano
 #elif defined(ARDUINO_AVR_NANO)
 #define BOARD_TYPE F("Nano")
@@ -46,6 +47,7 @@ static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_P
 static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
   A0,A1,A2,A3,A6,A7
 };
+
 // Arduino Mega/Mega2560
 #elif defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_MEGA)
 #define BOARD_TYPE F("Mega")
@@ -60,6 +62,20 @@ const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = 
 const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
   A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13,A14,A15
 };
+
+// NUCLEO F411RE
+#elif defined(ARDUINO_NUCLEO_F411RE)
+#define BOARD_TYPE F("NUCLEO-F411RE")
+#define SECTOR_FLASH
+#define NUMBER_OF_DIGITAL_PINS 2
+#define NUMBER_OF_ANALOGUE_PINS 2
+const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
+  PC_10,PC_12,PC_2,PC_3
+};
+const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
+  PC_2,PC_3
+};
+
 #else
 #define CPU_TYPE_ERROR
 #endif

--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -54,30 +54,40 @@ static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
 #define HAS_EEPROM
 #define NUMBER_OF_DIGITAL_PINS 46   // D2 - D19, D22 - D49
 #define NUMBER_OF_ANALOGUE_PINS 16     // A0 - A15
-const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
+static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
   2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,22,23,24,25,26,27,28,29,
   30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,
   A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13,A14,A15
 };
-const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
+static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
   A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A11,A12,A13,A14,A15
 };
 
 // NUCLEO F411RE
+// The current pin map has pin conflicts which prevents normal operation, preparing to support only
 #elif defined(ARDUINO_NUCLEO_F411RE)
 #define BOARD_TYPE F("NUCLEO-F411RE")
 #define SECTOR_FLASH
-#define NUMBER_OF_DIGITAL_PINS 34
-#define NUMBER_OF_ANALOGUE_PINS 14
-const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
-  PC_10,PC_11,PC_12,PD_2,PA_13,PA_14,PA_15,PB_7,PC_13,PC_14,PC_15,PH_0,PH_1,    // CN7 digital
-  PC_9,PC_8,PC_6,PA_12,PA_11,PB_12,PB_6,PC_7,PA_9,PB_2,PA_8,PB_10,PB_15,PB_10,PB_15,PB_4,PB_14,PB_5,PB_13,PB_3,PA_10, // CN10 digital
-  PA_0,PA_1,PA_4,PB_0,PC_2,PC_1,PC_3,PC_0,   // CN7 analogue
-  PC_5,PA_5,PA_6,PA_7,PB_1,PC_4   // CN10 analogue
+// #define NUMBER_OF_DIGITAL_PINS 32
+// #define NUMBER_OF_ANALOGUE_PINS 14
+// static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
+//   PC_10,PC_11,PC_12,PD_2,PA_15,PB_7,PC_13,PC_14,PC_15,PH_0,PH_1,    // CN7 digital
+//   PC_9,PC_8,PC_6,PA_12,PA_11,PB_12,PB_6,PC_7,PA_9,PB_2,PA_8,PB_10,PB_15,PB_10,PB_15,PB_4,PB_14,PB_5,PB_13,PB_3,PA_10, // CN10 digital
+//   PA_0,PA_1,PA_4,PB_0,PC_2,PC_1,PC_3,PC_0,   // CN7 analogue
+//   PC_5,PA_5,PA_6,PA_7,PB_1,PC_4   // CN10 analogue
+// };
+// static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
+//   PA_0,PA_1,PA_4,PB_0,PC_2,PC_1,PC_3,PC_0,   // CN7 analogue
+//   PC_5,PA_5,PA_6,PA_7,PB_1,PC_4   // CN10 analogue
+// };
+#define NUMBER_OF_DIGITAL_PINS 2
+#define NUMBER_OF_ANALOGUE_PINS 2
+static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
+  PC_10,PC_11,
+  PC_5,PA_5
 };
-const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
-  PA_0,PA_1,PA_4,PB_0,PC_2,PC_1,PC_3,PC_0,   // CN7 analogue
-  PC_5,PA_5,PA_6,PA_7,PB_1,PC_4   // CN10 analogue
+static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
+  PC_5,PA_5
 };
 
 #else

--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -25,6 +25,7 @@
 // Arduino Uno
 #if defined(ARDUINO_AVR_UNO)
 #define BOARD_TYPE F("Uno")
+#define HAS_EEPROM
 #define NUMBER_OF_DIGITAL_PINS 12   // D2 - D13
 #define NUMBER_OF_ANALOGUE_PINS 4     // A0 - A3, cannot use A4/A5
 static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
@@ -36,6 +37,7 @@ static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
 // Arduino Nano
 #elif defined(ARDUINO_AVR_NANO)
 #define BOARD_TYPE F("Nano")
+#define HAS_EEPROM
 #define NUMBER_OF_DIGITAL_PINS 12   // D2 - D13
 #define NUMBER_OF_ANALOGUE_PINS 6     // A0 - A3, A6/A7, cannot use A4/A5
 static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
@@ -47,6 +49,7 @@ static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
 // Arduino Mega/Mega2560
 #elif defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_MEGA)
 #define BOARD_TYPE F("Mega")
+#define HAS_EEPROM
 #define NUMBER_OF_DIGITAL_PINS 46   // D2 - D19, D22 - D49
 #define NUMBER_OF_ANALOGUE_PINS 16     // A0 - A15
 const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
@@ -71,5 +74,13 @@ const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
 #define EXIORDAN 0xE4     // Flag an analogue input is being read
 #define EXIOWRD 0xE5      // Flag for digital write
 #define EXIORDD 0xE6      // Flag a digital input is being read
+
+/////////////////////////////////////////////////////////////////////////////////////
+//  Define version to store in EEPROM/FLASH in case this needs to change later
+//  This needs to be defined in order to invalidate contents if the structure changes
+//  in future releases.
+//
+#define EEPROM_VERSION 1
+#define FLASH_VERSION 1
 
 #endif

--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -67,13 +67,17 @@ const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
 #elif defined(ARDUINO_NUCLEO_F411RE)
 #define BOARD_TYPE F("NUCLEO-F411RE")
 #define SECTOR_FLASH
-#define NUMBER_OF_DIGITAL_PINS 2
-#define NUMBER_OF_ANALOGUE_PINS 2
+#define NUMBER_OF_DIGITAL_PINS 34
+#define NUMBER_OF_ANALOGUE_PINS 14
 const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
-  PC_10,PC_12,PC_2,PC_3
+  PC_10,PC_11,PC_12,PD_2,PA_13,PA_14,PA_15,PB_7,PC_13,PC_14,PC_15,PH_0,PH_1,    // CN7 digital
+  PC_9,PC_8,PC_6,PA_12,PA_11,PB_12,PB_6,PC_7,PA_9,PB_2,PA_8,PB_10,PB_15,PB_10,PB_15,PB_4,PB_14,PB_5,PB_13,PB_3,PA_10, // CN10 digital
+  PA_0,PA_1,PA_4,PB_0,PC_2,PC_1,PC_3,PC_0,   // CN7 analogue
+  PC_5,PA_5,PA_6,PA_7,PB_1,PC_4   // CN10 analogue
 };
 const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
-  PC_2,PC_3
+  PA_0,PA_1,PA_4,PB_0,PC_2,PC_1,PC_3,PC_0,   // CN7 analogue
+  PC_5,PA_5,PA_6,PA_7,PB_1,PC_4   // CN10 analogue
 };
 
 #else

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,5 @@ monitor_echo = yes
 platform = ststm32
 board = nucleo_f411re
 framework = arduino
-; build_flags = -std=c++17 -Os -g2
 monitor_speed = 115200
 monitor_echo = yes

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,3 +41,11 @@ board = megaatmega2560
 framework = arduino
 monitor_speed = 115200
 monitor_echo = yes
+
+[env:Nucleo-F411RE]
+platform = ststm32
+board = nucleo_f411re
+framework = arduino
+; build_flags = -std=c++17 -Os -g2
+monitor_speed = 115200
+monitor_echo = yes

--- a/version.h
+++ b/version.h
@@ -1,8 +1,10 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "0.0.3"
+#define VERSION "0.0.4"
 
+// 0.0.4 includes:
+//  - Add support for configuring I2C address via serial, save to EEPROM
 // 0.0.3 includes:
 //  - Bug fix for compilation on Mega
 // 0.0.2 includes:

--- a/version.h
+++ b/version.h
@@ -5,6 +5,7 @@
 
 // 0.0.4 includes:
 //  - Add support for configuring I2C address via serial, save to EEPROM
+//  - Add support for NUCLEO-F411RE
 // 0.0.3 includes:
 //  - Bug fix for compilation on Mega
 // 0.0.2 includes:

--- a/version.h
+++ b/version.h
@@ -5,7 +5,7 @@
 
 // 0.0.4 includes:
 //  - Add support for configuring I2C address via serial, save to EEPROM
-//  - Add support for NUCLEO-F411RE
+//  - Serial commands <R>, <W address>, <E>, <Z> - see doco
 // 0.0.3 includes:
 //  - Bug fix for compilation on Mega
 // 0.0.2 includes:

--- a/version.h
+++ b/version.h
@@ -1,15 +1,15 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "0.0.3-Alpha"
+#define VERSION "0.0.3"
 
-// 0.0.3-Alpha includes:
+// 0.0.3 includes:
 //  - Bug fix for compilation on Mega
-// 0.0.2-Alpha includes:
+// 0.0.2 includes:
 //  - Change from MCP23017 emulation to native DCC-EX device driver.
 //  - Digital input/output.
 //  - Analogue input.
-// 0.0.1-Alpha includes:
+// 0.0.1 includes:
 //  - MCP23017 digital I/O emulation (minus interrupts).
 
 #endif


### PR DESCRIPTION
Add EEPROM support for AVR, add basis of Nucleo F411RE support but not supported yet due to pin conflicts