### PR TITLE
18-bug-report-nano-not-working-as-expected

### DIFF
--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -363,13 +363,10 @@ void setVersion() {
   versionString.toCharArray(versionArray, versionString.length() + 1);
   version = strtok(versionArray, "."); // Split version on .
   versionBuffer[0] = atoi(version);  // Major first
-  Serial.println(versionBuffer[0]);
   version = strtok(NULL, ".");
   versionBuffer[1] = atoi(version);  // Minor next
-  Serial.println(versionBuffer[1]);
   version = strtok(NULL, ".");
   versionBuffer[2] = atoi(version);  // Patch last
-  Serial.println(versionBuffer[2]);
 }
 
 /*
@@ -515,9 +512,6 @@ void eraseI2CAddress() {
 
 #endif
 
-/*
-* Code to reset via software
-*/
 void reset() {
 #if defined(ARDUINO_ARCH_AVR)
   wdt_enable(WDTO_15MS);

--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -78,6 +78,12 @@ digitalConfig digitalPins[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS];
 analogueConfig analoguePins[NUMBER_OF_ANALOGUE_PINS];
 
 /*
+* Include required files and libraries.
+*/
+#include "version.h"
+#include <Wire.h>
+
+/*
 * Global variables here
 */
 /*
@@ -105,12 +111,6 @@ unsigned long lastPinDisplay = 0;   // Last time in millis we displayed DIAG inp
 #endif
 
 /*
-* Include required files and libraries.
-*/
-#include "version.h"
-#include <Wire.h>
-
-/*
 * Main setup function here.
 */
 void setup() {
@@ -130,13 +130,7 @@ void setup() {
   }
   Serial.print(F("Available at I2C address 0x"));
   Serial.println(i2cAddress, HEX);
-  // Put version into our array for the query later
-  version = strtok(VERSION, "."); // Split version on .
-  versionBuffer[0] = version[0] - '0';  // Major first
-  version = strtok(NULL, ".");
-  versionBuffer[1] = version[0] - '0';  // Minor next
-  version = strtok(NULL, ".");
-  versionBuffer[2] = version[0] - '0';  // Patch last
+  setVersion();
   Wire.begin(i2cAddress);
 // Need to intialise every pin in INPUT mode (no pull ups) for safe start
   for (uint8_t pin = 0; pin < NUMBER_OF_DIGITAL_PINS; pin++) {
@@ -359,6 +353,24 @@ void displayPins() {
   }
 }
 #endif
+
+/*
+* Function to get the version from version.h char array to bytes nicely
+*/
+void setVersion() {
+  const String versionString = VERSION;
+  char versionArray[versionString.length() + 1];
+  versionString.toCharArray(versionArray, versionString.length() + 1);
+  version = strtok(versionArray, "."); // Split version on .
+  versionBuffer[0] = atoi(version);  // Major first
+  Serial.println(versionBuffer[0]);
+  version = strtok(NULL, ".");
+  versionBuffer[1] = atoi(version);  // Minor next
+  Serial.println(versionBuffer[1]);
+  version = strtok(NULL, ".");
+  versionBuffer[2] = atoi(version);  // Patch last
+  Serial.println(versionBuffer[2]);
+}
 
 /*
 * Function to read and process serial input for I2C address config

--- a/myConfig.example.h
+++ b/myConfig.example.h
@@ -25,6 +25,6 @@
 /////////////////////////////////////////////////////////////////////////////////////
 //  Delay between dumping the status of the port config if DIAG enabled
 // 
-#define DIAG_CONFIG_DELAY 5000
+#define DIAG_CONFIG_DELAY 5
 
 #endif

--- a/version.h
+++ b/version.h
@@ -8,6 +8,7 @@
 //  - Optimise sending version to device driver to remove compiler warnings
 //  - Diagnostics enabled/disabled via serial console
 //  - Diagnostic display delay configured via serial console
+//  - Added test modes for digital input with/without pullups, analogue input, digital output
 // 0.0.6 includes:
 //  - Add experimental support for NUCLEO-F411RE
 // 0.0.5 includes:

--- a/version.h
+++ b/version.h
@@ -6,6 +6,8 @@
 
 // 0.0.7 includes:
 //  - Optimise sending version to device driver to remove compiler warnings
+//  - Diagnostics enabled/disabled via serial console
+//  - Diagnostic display delay configured via serial console
 // 0.0.6 includes:
 //  - Add experimental support for NUCLEO-F411RE
 // 0.0.5 includes:

--- a/version.h
+++ b/version.h
@@ -2,8 +2,10 @@
 #define VERSION_H
 
 // Version must only ever be numeric in order to be able to send it to the CommandStation
-#define VERSION "0.0.6"
+#define VERSION "0.0.7"
 
+// 0.0.7 includes:
+//  - Optimise sending version to device driver to remove compiler warnings
 // 0.0.6 includes:
 //  - Add experimental support for NUCLEO-F411RE
 // 0.0.5 includes:


### PR DESCRIPTION
Optimised version to device driver code, added test modes, enable/disable diags via serial console.

Cannot do anything about <Z> on old bootloader Nano at present.