### PR TITLE
Add-pro-mini

### DIFF
--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -116,6 +116,11 @@ bool outputTesting = false;   // Flag that digital output testing is enabled/dis
 bool pullupTesting = false;   // Flag that digital input testing with pullups is enabled/disabled
 unsigned long lastOutputTest = 0;   // Last time in millis we swapped output test state
 bool outputTestState = LOW;   // Flag to set outputs high or low for testing
+// Ensure test modes defined in myConfig.h have values
+#define ANALOGUE_TEST 1
+#define INPUT_TEST 2
+#define OUTPUT_TEST 3
+#define PULLUP_TEST 4
 
 /*
 * Main setup function here.
@@ -146,6 +151,15 @@ void setup() {
   initialisePins();
   Wire.onReceive(receiveEvent);
   Wire.onRequest(requestEvent);
+#if (TEST_MODE == ANALOGUE_TEST)
+  testAnalogue(true);
+#elif (TEST_MODE == INPUT_TEST)
+  testInput(true);
+#elif (TEST_MODE == OUTPUT_TEST)
+  testOutput(true);
+#elif (TEST_MODE == PULLUP_TEST)
+  testPullup(true);
+#endif
 }
 
 /*
@@ -657,6 +671,7 @@ void testInput(bool enable) {
       if (digitalPinMap[pin]) {
         digitalPins[pin].direction = 1;
         digitalPins[pin].pullup = 0;
+        digitalPins[pin].enable = 1;
       }
     }
   } else {
@@ -706,6 +721,7 @@ void testPullup(bool enable) {
       if (digitalPinMap[pin]) {
         digitalPins[pin].direction = 1;
         digitalPins[pin].pullup = 1;
+        digitalPins[pin].enable = 1;
       }
     }
   } else {

--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -35,9 +35,13 @@ static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
   A0,A1,A2,A3
 };
 
-// Arduino Nano
-#elif defined(ARDUINO_AVR_NANO)
+// Arduino Nano or Pro Mini
+#elif defined(ARDUINO_AVR_NANO) || defined(ARDUINO_AVR_PRO)
+#if defined(ARDUINO_AVR_NANO)
 #define BOARD_TYPE F("Nano")
+#elif defined(ARDUINO_AVR_PRO)
+#define BOARD_TYPE F("Pro Mini")
+#endif
 #define HAS_EEPROM
 #define NUMBER_OF_DIGITAL_PINS 12   // D2 - D13
 #define NUMBER_OF_ANALOGUE_PINS 6     // A0 - A3, A6/A7, cannot use A4/A5

--- a/myConfig.example.h
+++ b/myConfig.example.h
@@ -27,4 +27,18 @@
 // 
 #define DIAG_CONFIG_DELAY 5
 
+/////////////////////////////////////////////////////////////////////////////////////
+//  Enable test mode - ensure only one test mode is active at one time.
+//  This is handy if serial input doesn't work for commands for some reason. 
+// 
+//  ANALOGUE - equivalent of <A>
+//  INPUT - equivalent of <I>
+//  OUTPUT - equivalent of <O>
+//  PULLUP - equivalent of <P>
+// 
+// #define TEST_MODE ANALOGUE_TEST
+// #define TEST_MODE INPUT_TEST
+// #define TEST_MODE OUTPUT_TEST
+// #define TEST_MODE PULLUP_TEST
+
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,8 @@ default_envs =
 	nanoatmega328
 	uno
 	mega2560
+	pro16MHzatmega328
+	pro8MHzatmega328
 	Nucleo-F411RE
 src_dir = .
 include_dir = .
@@ -28,6 +30,20 @@ monitor_echo = yes
 [env:nanoatmega328]
 platform = atmelavr
 board = nanoatmega328
+framework = arduino
+monitor_speed = 115200
+monitor_echo = yes
+
+[env:pro16MHzatmega328]
+platform = atmelavr
+board = pro16MHzatmega328
+framework = arduino
+monitor_speed = 115200
+monitor_echo = yes
+
+[env:pro8MHzatmega328]
+platform = atmelavr
+board = pro8MHzatmega328
 framework = arduino
 monitor_speed = 115200
 monitor_echo = yes

--- a/version.h
+++ b/version.h
@@ -2,8 +2,10 @@
 #define VERSION_H
 
 // Version must only ever be numeric in order to be able to send it to the CommandStation
-#define VERSION "0.0.8"
+#define VERSION "0.0.9"
 
+// 0.0.9 includes:
+//  - Add support for Arduino Pro Mini
 // 0.0.8 includes:
 //  - Add pin initialisation function to tests and when receiving pin config
 //  - Always display when receiving pin config

--- a/version.h
+++ b/version.h
@@ -6,6 +6,7 @@
 
 // 0.0.9 includes:
 //  - Add support for Arduino Pro Mini
+//  - Add option to enable tests via myConfig.h
 // 0.0.8 includes:
 //  - Add pin initialisation function to tests and when receiving pin config
 //  - Always display when receiving pin config


### PR DESCRIPTION
Add support for Arduino Pro Mini (Nano pin map).

Add option to enable test modes from myConfig.h in case serial commands don't work.