### PR TITLE
31-to-do-optimise-read-speed

### DIFF
--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -133,6 +133,7 @@ static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
 #define EXIORDAN 0xE4     // Flag an analogue input is being read
 #define EXIOWRD 0xE5      // Flag for digital write
 #define EXIORDD 0xE6      // Flag a digital input is being read
+#define EXIOENAN 0xE7     // Flag to enable an analogue input pin
 
 /////////////////////////////////////////////////////////////////////////////////////
 //  Define version to store in EEPROM/FLASH in case this needs to change later

--- a/version.h
+++ b/version.h
@@ -2,8 +2,10 @@
 #define VERSION_H
 
 // Version must only ever be numeric in order to be able to send it to the CommandStation
-#define VERSION "0.0.10"
+#define VERSION "0.0.11"
 
+// 0.0.11 includes:
+//  - Optimise speed of transferring inputs to the device driver by sending all at once
 // 0.0.10 includes:
 //  - Add support for Nucleo F412ZG
 //  - Correct F411RE pin map


### PR DESCRIPTION
Digital and analogue reads are now done as a stream of bytes to improve read speeds for sensors/inputs.