### PR TITLE
Initial v0.0.13 SAMD support

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,9 +16,7 @@ jobs:
     - name: Copy generic config over
       run: cp myConfig.example.h myConfig.h
     - name: Install PlatformIO dependencies
-      run: |
-        pio settings set force_verbose Yes
-        pio pkg install
+      run: pio pkg install
     - name: Copy F412ZG variant files
       run: |
         mkdir -p ~/.platformio/platforms/ststm32/boards

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Copy generic config over
       run: cp myConfig.example.h myConfig.h
     - name: Install PlatformIO dependencies
-      run: pio pkg install
+      run: |
+        pio settings set force_verbose Yes
+        pio pkg install
     - name: Copy F412ZG variant files
       run: |
         mkdir -p ~/.platformio/platforms/ststm32/boards

--- a/SupportedDevices.h
+++ b/SupportedDevices.h
@@ -127,6 +127,26 @@ static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
 #define I2C_SDA PB9
 #define I2C_SCL PB8
 
+// Arduino Zero (SAMD21) using native USB - EXPERIMENTAL, in need of testing
+// Pins not available for use:
+// XTAL pins - PA00, PA01
+// USB pins - USB_HOST_ENABLE (D27), USB_DM (D28), USB_DP (D29)
+// I2C pins - SDA (PA22/D20), SCL (PA23,D21)
+// LED pins - BuiltinLED (D13), RxLED (D25), TxLED (D26)
+// AREF pin - AREF (42)
+#elif defined(ARDUINO_ARCH_SAMD)
+#define BOARD_TYPE F("Arduino Zero or Clone")
+#define NUMBER_OF_DIGITAL_PINS 27
+#define NUMBER_OF_ANALOGUE_PINS 6
+static const uint8_t digitalPinMap[NUMBER_OF_DIGITAL_PINS + NUMBER_OF_ANALOGUE_PINS] = {
+  0,1,2,3,4,5,6,7,8,9,10,11,12,13,A0,A1,A2,A3,A4,A5,22,23,24,38,39,40,41
+};
+static const uint8_t analoguePinMap[NUMBER_OF_ANALOGUE_PINS] = {
+  A0, A1, A2, A3, A4, A5
+};
+#define I2C_SDA PA22
+#define I2C_SCL PA23
+
 #else
 #define CPU_TYPE_ERROR
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ default_envs =
 	pro8MHzatmega328
 	Nucleo-F411RE
 	Nucleo-F412ZG
+	SAMD21
 src_dir = .
 include_dir = .
 
@@ -81,3 +82,10 @@ monitor_echo = yes
 build_flags = -std=c++17 -Os -g2
 upload_protocol = stlink
 build_src_filter = +<*> -<.git/> -<.svn/> -<f412zg_variant_files/>
+
+[env:SAMD21]
+platform = atmelsam
+board = zeroUSB
+framework = arduino
+monitor_speed = 115200
+monitor_echo = yes

--- a/version.h
+++ b/version.h
@@ -2,8 +2,10 @@
 #define VERSION_H
 
 // Version must only ever be numeric in order to be able to send it to the CommandStation
-#define VERSION "0.0.12"
+#define VERSION "0.0.13"
 
+// 0.0.13 includes:
+//  - Experimental support for SAMD21 Arduino Zero clones using native USB serial comms
 // 0.0.12 includes:
 //  - Add configuration option to disable internal I2C pullups
 // 0.0.11 includes:


### PR DESCRIPTION
Compiles fine - was tested against v0.0.8 functionality, and am assuming later functionality (pullups, multiple IO reads, etc.) all work as advertised across architectures.