### PR TITLE
Declare diag, allocate analogue pin map

### DIFF
--- a/EX-IOExpander.ino
+++ b/EX-IOExpander.ino
@@ -79,7 +79,7 @@ uint8_t* analoguePinMap;  // Map which analogue pin's value is in which byte
 bool outputTestState = LOW;   // Flag to set outputs high or low for testing
 
 #ifdef DIAG
-  diag = true;
+  bool diag = true;
 #else
   bool diag = false;
 #endif

--- a/pin_io_functions.cpp
+++ b/pin_io_functions.cpp
@@ -47,6 +47,7 @@ void setupPinDetails() {
   digitalPinBytes = numDigitalPins / 8;
   digitalPinStates = (byte*) calloc(digitalPinBytes, 1);
   analoguePinStates = (byte*) calloc(analoguePinBytes, 1);
+  analoguePinMap = (uint8_t*) calloc(numAnaloguePins, 1);
 }
 
 /*

--- a/version.h
+++ b/version.h
@@ -2,8 +2,11 @@
 #define VERSION_H
 
 // Version must only ever be numeric in order to be able to send it to the CommandStation
-#define VERSION "0.0.18"
+#define VERSION "0.0.19"
 
+// 0.0.19 includes:
+//  - Fix bug where "diag" was not declared correctly causing compiler error when diags enabled
+//  - Fix bug where the analogue inputs were not working
 // 0.0.18 includes:
 //  - Move all serial output away from I2C receiveEvent() to avoid slowing events down
 // 0.0.17 includes:


### PR DESCRIPTION
Fixed bug where enabling DIAG in myConfig.h caused compile error due to no declaration.

Fixed but with analogue inputs not working due to pin map array not having size set.