### PR TITLE
Add basic support for shift-register handling

### DIFF
--- a/defines.h
+++ b/defines.h
@@ -168,6 +168,8 @@ struct ServoData {
 #define EXIOINITA 0xE8    // Flag to send analogue pin info
 #define EXIOPINS 0xE9     // Flag we need to send pin counts
 #define EXIOWRAN 0xEA     // Flag we're receiving an analogue write (PWM)
+#define EXIOSHIFTIN  0xEB
+#define EXIOSHIFTOUT 0xEC
 #define EXIOERR 0xEF      // Flag something has errored to send to device driver
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/shiftio_functions.cpp
+++ b/shiftio_functions.cpp
@@ -1,0 +1,84 @@
+#include <Arduino.h>
+#include "shiftio_functions.h"
+#include "globals.h"   // pinMap[], pinNameMap[], numPins
+
+static bool mapPins(uint8_t clk, uint8_t latch, uint8_t data,
+                    uint8_t &pClk, uint8_t &pLatch, uint8_t &pData) {
+  if (clk >= numPins || latch >= numPins || data >= numPins) return false;
+  pClk   = pinMap[clk].physicalPin;
+  pLatch = pinMap[latch].physicalPin;
+  pData  = pinMap[data].physicalPin;
+  return true;
+}
+
+static uint8_t shiftInByte_phys(uint8_t pClk, uint8_t pLatch, uint8_t pData) {
+  uint8_t value = 0;
+
+  digitalWrite(pLatch, HIGH);
+  delayMicroseconds(1);
+  digitalWrite(pLatch, LOW);
+
+  for (int i = 0; i < 8; i++) {
+    digitalWrite(pClk, LOW);
+    delayMicroseconds(1);
+
+    if (digitalRead(pData)) value |= (1 << (7 - i));
+
+    digitalWrite(pClk, HIGH);
+    delayMicroseconds(1);
+  }
+  return value;
+}
+
+static void shiftOutByte_phys(uint8_t pClk, uint8_t pData, uint8_t value) {
+  for (int i = 7; i >= 0; i--) {
+    digitalWrite(pData, (value >> i) & 0x01);
+    digitalWrite(pClk, HIGH);
+    delayMicroseconds(1);
+    digitalWrite(pClk, LOW);
+  }
+}
+
+void exioShiftInBytes(uint8_t clk, uint8_t latch, uint8_t data, uint8_t* out, uint8_t nBytes) {
+  uint8_t pClk, pLatch, pData;
+  if (!mapPins(clk, latch, data, pClk, pLatch, pData)) {
+    // fail-safe: return all 0xFF so you can spot it (or all 0x00, your choice)
+    for (uint8_t i = 0; i < nBytes; i++) out[i] = 0xFF;
+    return;
+  }
+
+  pinMode(pClk, OUTPUT);
+  pinMode(pLatch, OUTPUT);
+  pinMode(pData, INPUT_PULLUP);
+  digitalWrite(pClk, LOW);
+  digitalWrite(pLatch, LOW);
+
+  USB_SERIAL.print(F("SHIFTIN idx "));
+  USB_SERIAL.print(clk); USB_SERIAL.print("/");
+  USB_SERIAL.print(latch); USB_SERIAL.print("/");
+  USB_SERIAL.print(data); USB_SERIAL.print(F(" => phys "));
+  USB_SERIAL.print(pClk); USB_SERIAL.print("/");
+  USB_SERIAL.print(pLatch); USB_SERIAL.print("/");
+  USB_SERIAL.println(pData);
+
+  for (uint8_t i = 0; i < nBytes; i++) {
+    out[i] = shiftInByte_phys(pClk, pLatch, pData);
+  }
+}
+
+void exioShiftOutBytes(uint8_t clk, uint8_t latch, uint8_t data, const uint8_t* in, uint8_t nBytes) {
+  uint8_t pClk, pLatch, pData;
+  if (!mapPins(clk, latch, data, pClk, pLatch, pData)) return;
+
+  pinMode(pClk, OUTPUT);
+  pinMode(pLatch, OUTPUT);
+  pinMode(pData, OUTPUT);
+  digitalWrite(pClk, LOW);
+  digitalWrite(pLatch, LOW);
+
+  for (int i = (int)nBytes - 1; i >= 0; i--) {
+    shiftOutByte_phys(pClk, pData, in[i]);
+  }
+
+  digitalWrite(pLatch, HIGH);
+}

--- a/shiftio_functions.h
+++ b/shiftio_functions.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <Arduino.h>
+
+void exioShiftInBytes(uint8_t clk, uint8_t latch, uint8_t data, uint8_t* out, uint8_t nBytes);
+void exioShiftOutBytes(uint8_t clk, uint8_t latch, uint8_t data, const uint8_t* in, uint8_t nBytes);


### PR DESCRIPTION
I have been tinkering with a personal fork of the EX-IOExpander codebase to see if I could add shift-register support.

My primary objective was to add support for duinoNodes (DNIN8, DNOU8, etc.) directly connected to an Arduino running EX-IOExpander.

This is the EX-IOExpander portion of the codebase, please use it for reference as needed. For the CommandStation-EX code, please visit this PR:
https://github.com/DCC-EX/CommandStation-EX/pull/501

The logic adds a basic shift-register transport to EX-IOExpander over the existing I2C protocol.

1. Introduces two new I2C commands:

- **EXIOSHIFTIN (0xEB):** host provides [clkIndex, latchIndex, dataIndex, nBytes]; firmware clocks in nBytes from a chained shift-register input and returns [EXIORDY][byte0..byteN-1].
- **EXIOSHIFTOUT (0xEC):** host provides [clkIndex, latchIndex, dataIndex, nBytes, payload...]; firmware shifts nBytes out and returns [EXIORDY].

2. Pins are addressed using the expander’s pin index space, then mapped to the MCU’s physical pins via pinMap[] so host code can use VPIN references while the firmware uses correct physical GPIO numbers.

3. Implements a dedicated shift IO helper (shiftio_functions.*):

- Configure CLK/LATCH as outputs and DATA as input with pull-up for shift-in
- Latch and Clock MSB-first for compatibility with existing duinoNodes behavior
- Shifts output data MSB-first and latches once per chain

4. Response buffering and length are capped (max 16 bytes) to stay safely within I2C payload limits.
5. Does not change existing EX-IOExpander pin IO behavior - Shift IO is a new, explicitly-invoked path via the new commands.

Note there is currently no protection from trying to use a pin for both digital reads/writes AND shift-registers at the same time. I have no idea what will happen if you try this, although it's likely the shift-register pins will take precedence.